### PR TITLE
backport 1934 into 1927

### DIFF
--- a/DSharpPlus.Commands/ContextChecks/RequirePermissionsCheck.cs
+++ b/DSharpPlus.Commands/ContextChecks/RequirePermissionsCheck.cs
@@ -1,5 +1,9 @@
 #pragma warning disable IDE0046
+
 using System.Threading.Tasks;
+
+using DSharpPlus.Commands.Processors.SlashCommands;
+using DSharpPlus.Entities;
 
 namespace DSharpPlus.Commands.ContextChecks;
 
@@ -7,6 +11,16 @@ internal sealed class RequirePermissionsCheck : IContextCheck<RequirePermissions
 {
     public ValueTask<string?> ExecuteCheckAsync(RequirePermissionsAttribute attribute, CommandContext context)
     {
+        if (context is SlashCommandContext slashContext)
+        {
+            if (!slashContext.Interaction.AppPermissions.HasPermission(attribute.BotPermissions))
+            {
+                return ValueTask.FromResult<string?>("The bot did not have the needed permissions to execute this command.");
+            }
+
+            return ValueTask.FromResult<string?>(null);
+        }
+
         if (context.Guild is null)
         {
             return ValueTask.FromResult<string?>(RequireGuildCheck.ErrorMessage);


### PR DESCRIPTION
# Summary
#1927 is a working DSP version for the sharded client, most things after that break.
however, #1934 is a fix we need to solve "pre-flight checks" errors
